### PR TITLE
Fixed key name for instance association

### DIFF
--- a/lib/stackdriver.js
+++ b/lib/stackdriver.js
@@ -71,7 +71,7 @@ function StackdriverBackend(startupTime, config, emitter) {
 StackdriverBackend.prototype.add_point_to_message = function(stackdriverMessage, point) {
 	// decorate with instance ID if source was set
 	if (this.source) {
-		point.instanceId = this.source;
+		point.instance = this.source;
 	}
 	// add the point to the message object
 	stackdriverMessage.data.push(point);


### PR DESCRIPTION
Forgot to include this along with the earlier issue I filed.

The key should be `instance` and not `instanceId`
