### PR TITLE
Conf settings to disable unwanted metric types, and add set types

### DIFF
--- a/lib/stackdriver.js
+++ b/lib/stackdriver.js
@@ -297,7 +297,7 @@ StackdriverBackend.prototype.flush = function(timestamp, metrics) {
 		for (set_key in metrics.sets) {
 			if (set_key.match(internalMetricsPrefix) != null) {
 				if (this.debug) {
-					util.log("Skipping internal metric " + gauge_key);
+					util.log("Skipping internal metric " + set_key);
 				}
 				continue;
 			} else {


### PR DESCRIPTION
This pull request has two changes (sorry):
#### Config settings to disable unwanted metric types
- I didn't need both metric counts and rates, so I wanted a config flag for it. While I was there, I added flags for the rest of the metrics.
- Everything defaults to true because it seemed like the least surprising thing to do. I'm not sold on sending counters _and_ rates for a metric, but I don't see a better default than "everything on."
- I haven't added examples of this to Readme.md -- let me know if you'd like me to add that before pulling.
#### Set metrics
- We've been using them for a month with this patch to track concurrent users, seems solid.
