### PR TITLE
Add "sourceFromPrefix" support to infer the instance name from the metric prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please set flushInterval to 1 minute (60000 milliseconds) or more, as that is th
 ```js
 {
     flushInterval: 60000,
-    backends: [ "stackdriver-statsd-backend"], 
+    backends: [ "stackdriver-statsd-backend" ], 
     stackdriver: {
         apiKey: "YOUR_API_KEY_HERE"
     }
@@ -35,10 +35,24 @@ To associate the metrics with a particular instance (such as the one statsd is r
 ```js
 {
     flushInterval: 60000,
-    backends: [ "stackdriver-statsd-backend"], 
+    backends: [ "stackdriver-statsd-backend" ], 
     stackdriver: {
         apiKey: "YOUR_API_KEY_HERE",
         source: "AWS Instance ID here"
+    }
+}
+```
+
+If you are sending to Stackdriver from an aggregated metrics source (for example into a statsd cluster) the instance can be inferred from a prefix on the metric name rather than a fixed value.  If your metric names look like "_instanceName_|_metricName_", you would use:
+
+```js
+{
+    flushInterval: 60000,
+    backends: [ "stackdriver-statsd-backend" ], 
+    stackdriver: {
+        apiKey: "YOUR_API_KEY_HERE",
+        sourceFromPrefix: true,
+        sourcePrefixSeparator: "|"
     }
 }
 ```
@@ -48,7 +62,7 @@ To output additional logging information, add the debug parameter set to true.  
 ```js
 {
     flushInterval: 60000,
-    backends: [ "stackdriver-statsd-backend"], 
+    backends: [ "stackdriver-statsd-backend" ], 
     stackdriver: {
         apiKey: "YOUR_API_KEY_HERE",
         debug: "true"

--- a/lib/stackdriver.js
+++ b/lib/stackdriver.js
@@ -35,6 +35,8 @@ function StackdriverBackend(startupTime, config, emitter) {
 	var self = this;
 	this.apiKey = config.stackdriver.apiKey;
 	this.source = config.stackdriver.source;
+	this.sourceFromPrefix = ('sourceFromPrefix' in config.stackdriver) ? config.stackdriver.sourceFromPrefix : false;
+	this.sourcePrefixSeparator = ('sourcePrefixSeparator' in config.stackdriver) ? config.stackdriver.sourcePrefixSeparator : "|";
 	this.debug = config.stackdriver.debug;
 
 	// Let users filter out stats they won't use
@@ -64,7 +66,10 @@ function StackdriverBackend(startupTime, config, emitter) {
 	if (this.debug) {
 		util.log('Stackdriver backend is running in debug mode, extra logging will occur');
 	}
-	if (this.source) {
+
+	if (this.sourceFromPrefix) {
+		util.log('Source will be inferred from each metric prefix, separated by "' + this.sourcePrefixSeparator + '", all points sent to Stackdriver for that metric will be associated with that instance');
+	} else if (this.source) {
 		util.log('Source param set to ' + this.source + ', all points sent to Stackdriver will be associated with that instance');
 	}
 
@@ -82,8 +87,17 @@ function StackdriverBackend(startupTime, config, emitter) {
  * if the source is set in the config
  */
 StackdriverBackend.prototype.add_point_to_message = function(stackdriverMessage, point) {
-	// decorate with instance ID if source was set
-	if (this.source) {
+	// decorate with instance ID if source or sourceFromPrefix was set
+	if (this.sourceFromPrefix) {
+		var sep = point.name.indexOf(this.sourcePrefixSeparator);
+		if (sep <= 0) {
+			util.warn('No prefix separator ("' + this.sourcePrefixSeparator + '") found in metric name')
+			// note that we'll still send the point, just without an instance property
+		} else {
+			point.instance = point.name.substring(0, sep);
+			point.name = point.name.substring(sep + 1);
+		}
+	} else if (this.source) {
 		point.instance = this.source;
 	}
 	// add the point to the message object


### PR DESCRIPTION
We were contemplating using gossip_girl and a statsd cluster proxy to pre-aggregate our metrics (in order to reduce the network traffic between our network and Stackdriver's), and needed a way to (a) prevent the statsd cluster from commingling metrics from separate instances, and (b) ensure that the individual instances were preserved by the time the data got to Stackdriver.  Our solution was to prefix the instance name when gossip_girl blabbed to the statsd cluster, and then extract/strip the prefix when the cluster machines flush to Stackdriver.
