### PR TITLE
Fix variable contexts on autodetecting aws and gce

### DIFF
--- a/lib/stackdriver.js
+++ b/lib/stackdriver.js
@@ -100,7 +100,7 @@ function StackdriverBackend(startupTime, config, emitter) {
 
 		util.log('Source param set to ' + this.source + ', all points sent to Stackdriver will be associated with that instance');
 	}
-	// attach in the case that we don't have a source
+	// attach
 	emitter.on('flush', function(timestamp, metrics) {
 		self.flush(timestamp, metrics);
 	});


### PR DESCRIPTION
When using 'detect-aws' and 'detect-gce' as the sources, the exec() callback was attempting to set the source variable inside its own context, rather than the StackdriverBackend context, resulting in an invalid instance id.
