### PR TITLE
Update flush method to not log 'Max value is...'

### DIFF
--- a/lib/stackdriver.js
+++ b/lib/stackdriver.js
@@ -336,7 +336,6 @@ StackdriverBackend.prototype.flush = function(timestamp, metrics) {
         }
 			}
 			if (this.sendTimerMaxes && typeof(metrics.timer_data[timer_key]["upper"]) != "undefined") {
-			  util.log("Max value is " + metrics.timer_data[timer_key]["upper"])
 				this.add_point_to_message(stackdriverMessage, {
 					name : timer_key + ".max",
 					value : metrics.timer_data[timer_key]["upper"],


### PR DESCRIPTION
Should be consistent with min, sum, average etc

Alternatively, can update this to add it to the other methods with an `if (this.debug) { ... }`