### PR TITLE
Fix bug preventing decimal percentiles (i.e. 99.9) from being sent to…

### DIFF
--- a/lib/stackdriver.js
+++ b/lib/stackdriver.js
@@ -366,12 +366,13 @@ StackdriverBackend.prototype.flush = function(timestamp, metrics) {
 			if (this.sendTimerPercentiles) {
 				// send a point for each configured percentile, defaults to just 90th per statsd default
 				for (var i=0; i < this.percentileValues.length; i++) {
-				  if (typeof(metrics.timer_data[timer_key]["upper_" + this.percentileValues[i]]) == 'undefined') {
+				  var normalizedPercentile = this.percentileValues[i].toString().replace(".", "_");
+				  if (typeof(metrics.timer_data[timer_key]["upper_" + normalizedPercentile]) == 'undefined') {
 				    continue;
 				  }
 					this.add_point_to_message(stackdriverMessage, {
-						name : timer_key + "." + this.percentileValues[i] + "_pct",
-						value : metrics.timer_data[timer_key]["upper_" + this.percentileValues[i]],
+						name : timer_key + "." + normalizedPercentile + "_pct",
+						value : metrics.timer_data[timer_key]["upper_" + normalizedPercentile],
 						collected_at: timestamp
 					});
 				}


### PR DESCRIPTION
… stackdriver.

StatsD allows for configuring decimal percentiles. However, the logic in the Stackdriver backend did not account for transforming '.' into '_' to match how StatsD has the metric. This change alleviates that issues and ensure decimal percentiles being tracked are correctly sent along.

This PR replaces the closed [PR #11](https://github.com/Stackdriver/stackdriver-statsd-backend/pull/11) with a single, clean commit.
